### PR TITLE
Padronização dos Controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,26 @@
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+
+  console.error(publicErrorObject);
+
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors";
 
 async function query(queryObject) {
   let client;
@@ -8,8 +9,12 @@ async function query(queryObject) {
     const result = await client.query(queryObject);
     return result;
   } catch (error) {
-    console.error(error);
-    throw error;
+    const serviceErrorObject = new ServiceError({
+      message: "Erro na conexão com o Banco de Dados ou na query.",
+      cause: error,
+    });
+
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,11 +1,50 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Um erro interno não esperado aconteceu.", {
       cause,
     });
     this.name = "InternalServerError";
     this.action = "Entre em contato com o suporte.";
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super("Serviço indisponível no momento." || message, {
+      cause,
+    });
+    this.name = "ServiceError";
+    this.action = "Verifique se o serviço está disponível.";
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para esse endpoint.");
+    this.name = "MethodNotAllowedError";
+    this.action =
+      "Verifique se o método HTTP enviado é válido para este endpoint.";
+    this.statusCode = 405;
   }
 
   toJSON() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.6",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2088,6 +2089,11 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8550,6 +8556,18 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9589,6 +9607,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.6",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,53 +1,45 @@
+import { createRouter } from "next-connect";
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database";
+import controller from "infra/controller";
 
-export default async function migrations(request, response) {
-  const allowedMethods = ["GET", "POST"];
+const router = createRouter();
 
-  if (allowedMethods.includes(request.method)) {
-    let dbClient;
-    try {
-      dbClient = await database.getNewClient();
-      const defaultMigrationsOptions = {
-        dbClient: dbClient,
-        databaseUrl: process.env.DATABASE_URL,
-        dryRun: true,
-        dir: resolve("infra", "migrations"),
-        direction: "up",
-        verbose: true,
-        migrationsTable: "pgmigrations",
-        noLock: true,
-      };
+router.get(getHandler);
+router.post(postHandler);
 
-      if (request.method === "GET") {
-        const pendingMigrations = await migrationRunner(
-          defaultMigrationsOptions,
-        );
-        return response.status(200).json(pendingMigrations);
-      }
+export default router.handler(controller.errorHandlers);
 
-      if (request.method === "POST") {
-        const migratedMigrations = await migrationRunner({
-          ...defaultMigrationsOptions,
-          dryRun: false,
-        });
-
-        if (migratedMigrations.length > 0) {
-          return response.status(201).json(migratedMigrations);
-        }
-
-        return response.status(200).json(migratedMigrations);
-      }
-    } catch (error) {
-      console.error(error);
-      throw error;
-    } finally {
-      await dbClient.end();
-    }
-  } else {
-    return response.status(405).json({
-      error: `Method ${request.method} not allowed.`,
+async function getDatabaseMigrations({ dryRun = true }) {
+  const dbClient = await database.getNewClient();
+  try {
+    return await migrationRunner({
+      dbClient: dbClient,
+      databaseUrl: process.env.DATABASE_URL,
+      dryRun: dryRun,
+      dir: resolve("infra", "migrations"),
+      direction: "up",
+      verbose: true,
+      migrationsTable: "pgmigrations",
+      noLock: true,
     });
+  } finally {
+    await dbClient.end();
   }
+}
+
+async function getHandler(request, response) {
+  const pendingMigrations = await getDatabaseMigrations({});
+  return response.status(200).json(pendingMigrations);
+}
+
+async function postHandler(request, response) {
+  const migratedMigrations = await getDatabaseMigrations({ dryRun: false });
+
+  if (migratedMigrations.length > 0) {
+    return response.status(201).json(migratedMigrations);
+  }
+
+  return response.status(200).json(migratedMigrations);
 }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -27,8 +27,8 @@ async function status(request, response) {
       updated_at: updatedAt,
       dependencies: {
         database: {
-          max_connections: results.max_connections,
           opened_connections: results.opened_connections,
+          max_connections: results.max_connections,
           version: results.version,
         },
       },

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,42 +1,40 @@
+import { createRouter } from "next-connect";
 import database from "infra/database.js";
-import { InternalServerError } from "infra/errors";
+import controller from "infra/controller";
 
-async function status(request, response) {
-  try {
-    const updatedAt = new Date().toISOString();
+const router = createRouter();
 
-    const databaseVersion = await database.query("SHOW server_version;");
+router.get(getHandler);
 
-    const databaseMaxConnections = await database.query(
-      "SHOW max_connections;",
-    );
+export default router.handler(controller.errorHandlers);
 
-    const databaseName = process.env.POSTGRES_DB;
-    const databaseOpenedConnections = await database.query({
-      text: "SELECT COUNT(*)::INTEGER FROM pg_stat_activity WHERE datname = $1;",
-      values: [databaseName],
-    });
+async function getHandler(request, response) {
+  const updatedAt = new Date().toISOString();
 
-    const results = {
-      max_connections: parseInt(databaseMaxConnections.rows[0].max_connections),
-      opened_connections: databaseOpenedConnections.rows[0].count,
-      version: databaseVersion.rows[0].server_version,
-    };
+  const databaseVersion = await database.query("SHOW server_version;");
 
-    response.status(200).json({
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          opened_connections: results.opened_connections,
-          max_connections: results.max_connections,
-          version: results.version,
-        },
+  const databaseMaxConnections = await database.query("SHOW max_connections;");
+
+  const databaseName = process.env.POSTGRES_DB;
+  const databaseOpenedConnections = await database.query({
+    text: "SELECT COUNT(*)::INTEGER FROM pg_stat_activity WHERE datname = $1;",
+    values: [databaseName],
+  });
+
+  const results = {
+    max_connections: parseInt(databaseMaxConnections.rows[0].max_connections),
+    opened_connections: databaseOpenedConnections.rows[0].count,
+    version: databaseVersion.rows[0].server_version,
+  };
+
+  response.status(200).json({
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        opened_connections: results.opened_connections,
+        max_connections: results.max_connections,
+        version: results.version,
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({ cause: error });
-    response.status(500).json(publicErrorObject);
-  }
+    },
+  });
 }
-
-export default status;

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,26 @@
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving current system status", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para esse endpoint.",
+        action:
+          "Verifique se o método HTTP enviado é válido para este endpoint.",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Padroniza os Controllers dos endpoints `/migrations` e `/status`
2. Cria os erros `MethodNotAllowedError` e `ServiceError`
3. Faz o `InternalServerError` aceitar injeção do `statusCode`